### PR TITLE
Fixed typos

### DIFF
--- a/praesentationen/6/partdiff-6.tex
+++ b/praesentationen/6/partdiff-6.tex
@@ -152,7 +152,7 @@ x(\xi-1)&\qquad x<\xi
 
 \begin{frame}
 \frametitle{Greensche Funktion}
-\includegraphics[width=\hsize]{../../skript/images/green-1.png}
+\includegraphics[width=\hsize]{../../skript/images/green-1.pdf}
 \end{frame}
 
 \begin{frame}

--- a/skript/elliptisch.tex
+++ b/skript/elliptisch.tex
@@ -7,7 +7,7 @@
 \chapter{Elliptische Differentialgleichungen\label{chapter-elliptisch}}
 \index{Differentialgleichung!partielle!elliptische}
 \lhead{Elliptische PDGL}
-In diesem Kapitel untersuchen wird L"osungen elliptischer Differentialgleichungen
+In diesem Kapitel untersuchen wir L"osungen elliptischer Differentialgleichungen
 und entdecken dabei die Mittelwerteigenschaft
 harmonischer Funktionen sowie die Greensche Funktion, mit der sich f"ur
 die L"osung des Randwertproblems eine Formel aufstellen l"asst.

--- a/skript/geometrie.tex
+++ b/skript/geometrie.tex
@@ -709,7 +709,7 @@ L"osung gew"ohnlicher Differentialgleichungen ist zu jedem Wert
 aus der bereits bekannten partiellen Ableitung $\partial_yu(x,y)$
 die Steigung $\partial_xu(x,y)$ bestimmt, es ist somit plausibel, dass
 sich die L"osung "ahnlich wie bei der L"osung gew"ohnlicher Differentialgleichungen
-entwickeln l"asst. In voller Allgmeinheit ist dies nicht ganz einfach,
+entwickeln l"asst. In voller Allgemeinheit ist dies nicht ganz einfach,
 und f"ur unsere Zwecke auch nicht notwendig, denn alle wesentlichen
 Eigenschaften lassen sich an dem einfacheren Fall der quasilinearen
 partielle Differentialgleichung auch beobachten.

--- a/skript/hyperbolisch.tex
+++ b/skript/hyperbolisch.tex
@@ -562,7 +562,7 @@ immer schneller wird.
 
 \subsection{Charakteristiken f"ur elliptische und parabolische PDGL}
 Die oben entwickelte Theorie der Charakteristiken kann selbstverst"andlich
-auch auf elliptische und hyperbolische PDGL angewendet werden. Die
+auch auf elliptische und hyperbolische PDGL angewendet werden.
 Im elliptischen Fall hat die Differentialgleichung der Charakteristiken
 \[
 a\dot y(t)^2-2b\dot x(t)\dot y(t)+c\dot x(t)^2=0
@@ -728,7 +728,7 @@ eindeutig bestimmen.
 
 \subsection{Ein Spezialfall}
 Wir betrachten wieder den Spezialfall, in dem die Anfangswerte auf der
-Ebene $x_1=0$ vorgebeben sind, also
+Ebene $x_1=0$ vorgegeben sind, also
 \begin{align*}
 u(0,x_2,x_3)&=u_0(x_2,x_3),
 \\
@@ -758,7 +758,7 @@ A
 \subsection{Der allgemeine Fall}
 Wir betrachten die Funktion $\omega(x_1,x_2,x_3)$ als die erste
 Koordinaten eines neuen Koordinatensystems. Die Koordinaten in diesem
-neuen Sytem nennen wir $\omega_1,\dots,\omega_3$, sie sind Funktionen
+neuen System nennen wir $\omega_1,\dots,\omega_3$, sie sind Funktionen
 der alten Koordinaten
 \[
 \omega_1(x_1,x_2,x_3)=\omega(x_1,x_2,x_3)

--- a/skript/klassifikation.tex
+++ b/skript/klassifikation.tex
@@ -45,7 +45,7 @@ W"ahrend es bei einer Funktion von einer Variablen nur eine Ableitung
 jeder Ordnung gibt, hat eine Funktion von $n$ Variablen $n^k$ Ableitungen
 der Ordnung $k$.
 
-Eine Differntialgleichung liegt vor, wenn bekannt ist, wie verschiedenen
+Eine Differentialgleichung liegt vor, wenn bekannt ist, wie verschiedenen
 Ableitungen miteinander verkn"upft werden m"ussen.
 Die Wellengleichung hatte zum Beispiel die Form
 \begin{equation}
@@ -437,7 +437,7 @@ festzulegen, braucht man insgesamt zwei Bedingungen, zum Beispiel
 \end{itemize}
 
 \begin{beispiel}
-Selbst in dem einfachen Beispiel einer linearen Differentialgleichunge
+Selbst in dem einfachen Beispiel einer linearen Differentialgleichung
 zweiter Ordnung ist nicht jede beliebige Kombination von Randwertvorgaben
 m"oglich. Die Gleichung
 \[
@@ -796,7 +796,7 @@ von Randwerten und Normalableitungen vorzugeben.
 Dies gen"ugt jedoch noch nicht, zu entscheiden, ob durch diese
 Bedingungen die L"osungen eindeutig festgelegt sind.
 Dazu ist ein vertieftere Theorie n"otig. W"ahrend bei den gew"ohnlichen
-Differentialgieichungen eine relativ einfache Methode (Picard-Iteration)
+Differentialgleichungen eine relativ einfache Methode (Picard-Iteration)
 unter relativ milden Voraussetzungen zu beweisen  erlaubt, dass
 gew"ohnliche Differentialgleichungen zu gegebenen Anfangswerten eine
 eindeutig bestimmte L"osung haben, wenigstens f"ur eine gewisses Zeitinterval,

--- a/skript/parabolisch.tex
+++ b/skript/parabolisch.tex
@@ -8,9 +8,9 @@
 \index{Differentialgleichung!partielle!parabolische}
 \lhead{Parabolische PDGL}
 \rhead{}
-Vorangegangen Kapitel waren wir in der Lage, mit Hilfe der Greenschen
+Im vorangegangen Kapitel waren wir in der Lage, mit Hilfe der Greenschen
 Funktion eine L"osung eines elliptischen Randwertproblems zu finden.
-Dieser L"osungsweg hing ab Maxmimumprinzip.
+Dieser L"osungsweg hing vom Maxmimumprinzip ab.
 Es garantierte die Eindeutigkeit einer
 L"osung und machte damit die Konstruktion der Greenschen Funktion
 erst m"oglich.
@@ -18,13 +18,13 @@ erst m"oglich.
 \index{parabolische partielle Differentialgleichung}
 F"ur parabolische Differentialgleichung ist ein analoges Vorgehen
 m"oglich, wobei aber immer der Zeitkoordinate (oder der Richtung
-des Eigenvektors mit Eigenwert $0$ der Koeffzientenmatrix)
+des Eigenvektors mit Eigenwert $0$ der Koeffizientenmatrix)
 eine besondere Bedeutung zukommt.
 Dies wird in den ersten drei
 Abschnitten ohne Beweise  oder tiefer gehende Analyse zusammengefasst.
 
 Im Unterschied zu den elliptischen
-Gleichungen kann man die W"armeleitunsggleichung aber auch
+Gleichungen kann man die W"armeleitunsgleichung aber auch
 \index{Warmeleitungsgleichung@W\"armeleitungsgleichung}
 als eine ``Zeitentwicklungsgleichung'' verstehen, so wie die
 gew"ohnliche Differentialgleichung $\dot x=f(x,t)$
@@ -64,9 +64,9 @@ wohlbestimmt sind.
 \index{Maximumprinzip}
 \rhead{Maximum-Prinzip}
 In der Theorie der elliptischen PDGL war die Mittelwerteigenschaft
-der Ausgangspunkt f"ur den Beweis des Maximumpronzips. Obwohl
+der Ausgangspunkt f"ur den Beweis des Maximumprinzips. Obwohl
 diese Eigenschaft bei den 
-L"osungen der W"armeleitungsgleichung nicht mehr erf"ullst ist,
+L"osungen der W"armeleitungsgleichung nicht mehr erf"ullt ist,
 gilt f"ur sie ein Maximum-Minimum-Prinzip.
 \begin{satz}[Maximum-Minimum-Prinzip f"ur die W"armeleitungsgleichung]
 Sei $\Omega$ ein beschr"anktes Gebiet und

--- a/skript/separation.tex
+++ b/skript/separation.tex
@@ -190,7 +190,7 @@ Schritt. In den folgenden Abschnitten zeigen wir an Beispielen, wie
 dies m"oglich ist.
 
 \section{Separation f"ur lineare partielle Differentialgleichungen}
-Die Grundidee des Seoparationsverfahrens liefert eine Familie von Funktionen,
+Die Grundidee des Separationsverfahrens liefert eine Familie von Funktionen,
 von ein paar Integrationskonstanten abh"angen. Vorgegeben sind auf dem
 Rand aber beliebige Funktionen, es ist im Allgemeinen nicht m"oglich,
 durch richtige Wahl von wenigen Parametern beliebige Funktionen zu erhalten.
@@ -246,7 +246,7 @@ u(x)=\sum_{i=1}^\infty a_ku_k
 mit geeigneten Koeffizienten $a_k$, die so zu w"ahlen sind, dass die
 Randbedingungen erf"ullt sind.
 
-Inhomogene lineare partielle Differentialgleichungen k"ann man mit diesem
+Inhomogene lineare partielle Differentialgleichungen kann man mit diesem
 Verfahren ebenfalls l"osen. Dazu findet man zun"achst eine partikul"are
 L"osung $u_p$, welche die inhomogenen Differentialgleichung l"ost, ohne
 allerdings korrekte Randwerte zu liefern.


### PR DESCRIPTION
- Typos in einigen Kapiteln gefixt
- Falsche File Extension in Presentation 6 gefixt

Noch offen: In Abschnitt 2.5.3 wird auf das Kapitel Nichtlineare Partielle Differentialgleichungen verwiesen, welches im Skript jedoch nicht enthalten ist. Dabei ensteht eine undefinierte Referenz (Kapitel ??)
